### PR TITLE
Support Android S

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,19 +156,27 @@ costom_setttings() {
 }
 
 clean_wifi_logs() {
-  if [ "$is_clean_logs" == "true" ]; then
-    ui_print "- 正在停止tcpdump"
-    stop tcpdump
-    ui_print "- 正在停止cnss_diag"
-    stop cnss_diag
-    ui_print "- 正在停止logd"
-    stop logd
-    ui_print "- 正在清除MIUI WiFi log"
-    rm -rf /data/vendor/wlan_logs/*
-    setprop sys.miui.ndcd off >/dev/null
-    touch /data/adb/modules_update/Reducemiui/system.prop
-    echo "sys.miui.ndcd=off" >/data/adb/modules_update/Reducemiui/system.prop
-  fi
+    if [ "$is_clean_logs" == "true" ]; then
+        if [ "$SDK" == 30 ]; then
+            ui_print "- 正在停止tcpdump"
+            stop tcpdump
+            ui_print "- 正在停止cnss_diag"
+            stop cnss_diag
+        fi
+        if [ "$SDK" == 31 ]; then
+            ui_print "- 正在停止tcpdump"
+            stop vendor.tcpdump
+            ui_print "- 正在停止cnss_diag"
+            stop vendor.cnss_diag
+        fi
+        ui_print "- 正在停止logd"
+        stop logd
+        ui_print "- 正在清除MIUI WiFi log"
+        rm -rf /data/vendor/wlan_logs/*
+        setprop sys.miui.ndcd off >/dev/null
+        touch /data/adb/modules_update/Reducemiui/system.prop
+        echo "sys.miui.ndcd=off" >/data/adb/modules_update/Reducemiui/system.prop
+    fi
 }
 
 uninstall_useless_app() {

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,8 @@ is_clean_logs=true
 is_use_hosts=false
 # 默认dex2oat优化编译模式
 dex2oat_mode="everything"
+# 获取系统SDK
+SDK=$(getprop ro.system.build.version.sdk)
 # 精简数量累计
 num=0
 # 可编辑文件 命名为*.prop是为了编辑/查看时一目了然

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ pre_install() {
   module_minMagisk=19000
   module_description="精简系统服务，关闭部分系统日志 更新日期："
   # 模块版本号
-  version="2.82"
+  version="2.83"
   # 模块精简列表更新日期
   update_date="21.11.18"
   ui_print "- 提取模块文件"


### PR DESCRIPTION
On Android S, stop vendor.cnss_diag and stop vendor.tcpdump can be used 
In clean_ wifi_ Logs section